### PR TITLE
add permissions for opensearch proxy CI actor 

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -61,15 +61,6 @@ jobs:
       channel: ((slack-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed Credhub on staging
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
 
 - name: terraform-plan-credhub-staging
   plan:
@@ -92,6 +83,7 @@ jobs:
       TF_VAR_credhub_pages_concourse_client_actor: uaa-client:credhub_pages_client_staging
       TF_VAR_doomsday_readonly_actor: uaa-client:doomsday_readonly_staging
       TF_VAR_pgp_credhub_actor: uaa-client:pgp_credhub_client
+      TF_VAR_opensearch_proxy_ci_credhub_actor: uaa-client:opensearch_proxy_ci_client
       TF_VAR_credhub_server: https://credhub.fr-stage.cloud.gov
       TF_VAR_credhub_client_id: ((staging-credhub-client-id))
       TF_VAR_credhub_client_secret: ((staging-credhub-client-secret))
@@ -171,15 +163,6 @@ jobs:
       channel: ((slack-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
-  on_success:
-    put: slack
-    params:
-      text: |
-        :white_check_mark: Successfully deployed Credhub on Production
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-      channel: ((slack-channel))
-      username: ((slack-username))
-      icon_url: ((slack-icon-url))
 
 - name: terraform-plan-credhub-production
   plan:
@@ -205,6 +188,7 @@ jobs:
       TF_VAR_credhub_server: https://credhub.fr.cloud.gov
       TF_VAR_credhub_client_id: ((production-credhub-client-id))
       TF_VAR_credhub_client_secret: ((production-credhub-client-secret))
+      TF_VAR_opensearch_proxy_ci_credhub_actor: uaa-client:opensearch_proxy_ci_client
       CREDHUB_CA_CERT: ((common_ca_cert_store))
   - put: slack
     params:

--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -37,3 +37,9 @@ resource "credhub_permission" "pages_gpg" {
   actor      = var.pgp_credhub_actor
   operations = ["read","write","delete"]
 }
+
+resource "credhub_permission" "opensearch_proxy_ci" {
+  path       = "/concourse/main/opensearch-dashboards-cf-auth-proxy/*"
+  actor      = var.opensearch_proxy_ci_credhub_actor
+  operations = ["read","write","delete"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,3 +30,8 @@ variable "pgp_credhub_actor" {
   description = "The credhub client actor name. ie(uaa-client:my_client_name)"
   type        = string
 }
+
+variable "opensearch_proxy_ci_credhub_actor" {
+  description = "The credhub client actor name. ie(uaa-client:my_client_name)"
+  type        = string
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add permissions for opensearch proxy CI actor to read/write specified Credhub variables for its pipeline
- Remove on_success notifications

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Allows the OpenSearch auth proxy CI pipeline to update the Credhub variables for the pipeline, which will be used to keep test user passwords updated
