### PR TITLE
Adding pages_user_agent

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -185,6 +185,7 @@ jobs:
       TF_VAR_credhub_pages_concourse_client_actor: uaa-client:credhub_pages_client_production
       TF_VAR_doomsday_readonly_actor: uaa-client:doomsday_readonly_production
       TF_VAR_pgp_credhub_actor: uaa-client:pgp_credhub_client
+      TF_VAR_pages_user_agent: uaa-client:pages_user_agent_credhub_client
       TF_VAR_credhub_server: https://credhub.fr.cloud.gov
       TF_VAR_credhub_client_id: ((production-credhub-client-id))
       TF_VAR_credhub_client_secret: ((production-credhub-client-secret))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -83,6 +83,7 @@ jobs:
       TF_VAR_credhub_pages_concourse_client_actor: uaa-client:credhub_pages_client_staging
       TF_VAR_doomsday_readonly_actor: uaa-client:doomsday_readonly_staging
       TF_VAR_pgp_credhub_actor: uaa-client:pgp_credhub_client
+      TF_VAR_pages_user_agent: uaa-client:pages_user_agent_credhub_client
       TF_VAR_opensearch_proxy_ci_credhub_actor: uaa-client:opensearch_proxy_ci_client
       TF_VAR_credhub_server: https://credhub.fr-stage.cloud.gov
       TF_VAR_credhub_client_id: ((staging-credhub-client-id))

--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -43,3 +43,9 @@ resource "credhub_permission" "opensearch_proxy_ci" {
   actor      = var.opensearch_proxy_ci_credhub_actor
   operations = ["read","write","delete"]
 }
+
+resource "credhub_permission" "pages_user_agent" {
+  path       = "/concourse/pages/cf-build-tasks"
+  actor      = var.pages_user_agent
+  operations = ["read","write","delete"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -35,3 +35,8 @@ variable "opensearch_proxy_ci_credhub_actor" {
   description = "The credhub client actor name. ie(uaa-client:my_client_name)"
   type        = string
 }
+
+variable "pages_user_agent" {
+  description = "The credhub client actor name. ie(uaa-client:my_client_name)"
+  type        = string
+}


### PR DESCRIPTION
## Changes proposed in this pull request:
- Needed for new dedicated credhub client to retrieve waf slot variables
- Part of https://github.com/cloud-gov/private/issues/1966
-

## security considerations
Secret is generated and stored in tooling bosh credhub.
