### PR TITLE
Add star to pages_user_agent path

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -45,7 +45,7 @@ resource "credhub_permission" "opensearch_proxy_ci" {
 }
 
 resource "credhub_permission" "pages_user_agent" {
-  path       = "/concourse/pages/cf-build-tasks"
+  path       = "/concourse/pages/cf-build-tasks/*"
   actor      = var.pages_user_agent
   operations = ["read","write","delete"]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Needed for new dedicated credhub client to retrieve waf slot variables
- Modifies the path so hopefully all variables in that path are visible
- Part of https://github.com/cloud-gov/private/issues/1966 
-

## security considerations
Secret is generated and stored in tooling bosh credhub.
