### PR TITLE
Putting variable back after removing permission manually

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -44,8 +44,8 @@ resource "credhub_permission" "opensearch_proxy_ci" {
   operations = ["read","write","delete"]
 }
 
-#resource "credhub_permission" "pages_user_agent" {
-#  path       = "/concourse/pages/cf-build-tasks/*"
-#  actor      = var.pages_user_agent
-#  operations = ["read","write","delete"]
-#}
+resource "credhub_permission" "pages_user_agent" {
+  path       = "/concourse/pages/cf-build-tasks/*"
+  actor      = var.pages_user_agent
+  operations = ["read","write","delete"]
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- Undo for https://github.com/cloud-gov/deploy-credhub/pull/17, had to manually clean up the entry in the credhub db for staging
-

## Security considerations

Recreates the permission for the Pages concourse user that reads the waf user-agent header string variables, now with a bonus `/*` so the pathing works correctly.
