### PR TITLE
add permissions for OpenSearch credhub actor

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -85,6 +85,7 @@ jobs:
       TF_VAR_pgp_credhub_actor: uaa-client:pgp_credhub_client
       TF_VAR_pages_user_agent: uaa-client:pages_user_agent_credhub_client
       TF_VAR_opensearch_proxy_ci_credhub_actor: uaa-client:opensearch_proxy_ci_client
+      TF_VAR_opensearch_ci_credhub_actor: uaa-client:opensearch_ci_client
       TF_VAR_credhub_server: https://credhub.fr-stage.cloud.gov
       TF_VAR_credhub_client_id: ((staging-credhub-client-id))
       TF_VAR_credhub_client_secret: ((staging-credhub-client-secret))
@@ -191,6 +192,7 @@ jobs:
       TF_VAR_credhub_client_id: ((production-credhub-client-id))
       TF_VAR_credhub_client_secret: ((production-credhub-client-secret))
       TF_VAR_opensearch_proxy_ci_credhub_actor: uaa-client:opensearch_proxy_ci_client
+      TF_VAR_opensearch_ci_credhub_actor: uaa-client:opensearch_ci_client
       CREDHUB_CA_CERT: ((common_ca_cert_store))
   - put: slack
     params:

--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -49,3 +49,9 @@ resource "credhub_permission" "pages_user_agent" {
   actor      = var.pages_user_agent
   operations = ["read","write","delete"]
 }
+
+resource "credhub_permission" "opensearch_ci" {
+  path       = "/concourse/main/deploy-logs-opensearch/*"
+  actor      = var.opensearch_proxy_ci_credhub_actor
+  operations = ["read","write","delete"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -40,3 +40,7 @@ variable "pages_user_agent" {
   description = "The credhub client actor name. ie(uaa-client:my_client_name)"
   type        = string
 }
+variable "opensearch_ci_credhub_actor" {
+  description = "The credhub client actor name. ie(uaa-client:my_client_name)"
+  type        = string
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

- add permissions for opensearch proxy CI actor to read/write specified Credhub variables for its pipeline

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Allows the OpenSearch deployment CI pipeline to update the Credhub variables for the pipeline, which will be used to keep test user passwords updated
