### PR TITLE
fix actor reference for Credhub opensearch CI permissions

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -10,8 +10,8 @@ provider "credhub" {
 }
 
 resource "credhub_user" "concourse_pages_user" {
-  name            = "concourse_pages_user"
-  username        = "concourse-pages-user"
+  name     = "concourse_pages_user"
+  username = "concourse-pages-user"
 }
 
 resource "credhub_permission" "credhub_pages_concourse_permission" {
@@ -29,29 +29,29 @@ resource "credhub_permission" "doomsday_readonly" {
 resource "credhub_permission" "pgp" {
   path       = "/concourse/main/cloud-gov-pgp-keys"
   actor      = var.pgp_credhub_actor
-  operations = ["read","write","delete"]
+  operations = ["read", "write", "delete"]
 }
 
 resource "credhub_permission" "pages_gpg" {
   path       = "/concourse/pages/cloud-gov-pages-gpg-keys"
   actor      = var.pgp_credhub_actor
-  operations = ["read","write","delete"]
+  operations = ["read", "write", "delete"]
 }
 
 resource "credhub_permission" "opensearch_proxy_ci" {
   path       = "/concourse/main/opensearch-dashboards-cf-auth-proxy/*"
   actor      = var.opensearch_proxy_ci_credhub_actor
-  operations = ["read","write","delete"]
+  operations = ["read", "write", "delete"]
 }
 
 resource "credhub_permission" "pages_user_agent" {
   path       = "/concourse/pages/cf-build-tasks/*"
   actor      = var.pages_user_agent
-  operations = ["read","write","delete"]
+  operations = ["read", "write", "delete"]
 }
 
 resource "credhub_permission" "opensearch_ci" {
   path       = "/concourse/main/deploy-logs-opensearch/*"
-  actor      = var.opensearch_proxy_ci_credhub_actor
-  operations = ["read","write","delete"]
+  actor      = var.opensearch_ci_credhub_actor
+  operations = ["read", "write", "delete"]
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- fix actor reference for Credhub opensearch CI permissions, which should be `var.opensearch_ci_credhub_actor`, not `var.opensearch_proxy_ci_credhub_actor`
- Other changes are just formatting auto-applied by my code editor

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, this code does not expose any sensitive information
