### PR TITLE
update permission resource name for OpenSearch CI credhub permissions

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -50,7 +50,7 @@ resource "credhub_permission" "pages_user_agent" {
   operations = ["read", "write", "delete"]
 }
 
-resource "credhub_permission" "opensearch_ci" {
+resource "credhub_permission" "opensearch_ci_permission" {
   path       = "/concourse/main/deploy-logs-opensearch/*"
   actor      = var.opensearch_ci_credhub_actor
   operations = ["read", "write", "delete"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- update permission resource name for OpenSearch CI credhub permissions so that TF apply will work

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, the Terraform resources are not sensitive
