### PR TITLE
Dropping the number of prod vms to 2

### DIFF
--- a/variables/production.yml
+++ b/variables/production.yml
@@ -1,6 +1,6 @@
 deployment_name: credhub-production
 common_name: credhub.fr.cloud.gov
-instances: 3
+instances: 2
 azs: [z1,z2]
 network_name: production-credhub
 credhub_vm_type: t3.medium


### PR DESCRIPTION
## Changes proposed in this pull request:

- The credhub deploy is across two az's.  Having 1 vm in each availability zone is all that is required for HA, the third VM doesn't help with additional redundancy.
- Part of https://github.com/cloud-gov/product/issues/2836
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Reduces the number of vms deployed
