### PR TITLE
pgp read for pages

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -38,6 +38,12 @@ resource "credhub_permission" "pages_gpg" {
   operations = ["read", "write", "delete"]
 }
 
+resource "credhub_permission" "pgp_pages_read" {
+  path       = "/concourse/main/cloud-gov-pgp-keys"
+  actor      = var.credhub_pages_concourse_client_actor
+  operations = ["read"]
+}
+
 resource "credhub_permission" "opensearch_proxy_ci" {
   path       = "/concourse/main/opensearch-dashboards-cf-auth-proxy/*"
   actor      = var.opensearch_proxy_ci_credhub_actor


### PR DESCRIPTION
## Changes proposed in this pull request:
- Pages needs to verify some platform repos so they need our pgp keys to confirm
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None this is read only. 
