### PR TITLE
giving permissions to write new credhub entry

### DIFF
--- a/terraform/acl.tf
+++ b/terraform/acl.tf
@@ -38,10 +38,10 @@ resource "credhub_permission" "pages_gpg" {
   operations = ["read", "write", "delete"]
 }
 
-resource "credhub_permission" "pgp_pages_read" {
-  path       = "/concourse/main/cloud-gov-pgp-keys"
-  actor      = var.credhub_pages_concourse_client_actor
-  operations = ["read"]
+resource "credhub_permission" "pgp_cloud_for_pages" {
+  path       = "/concourse/pages/cloud-gov-pgp-keys"
+  actor      = var.pgp_credhub_actor
+  operations = ["read", "write", "delete"]
 }
 
 resource "credhub_permission" "opensearch_proxy_ci" {


### PR DESCRIPTION
## Changes proposed in this pull request:

- concourse cant read between teams so we have to duplicate/sync it anyways
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None